### PR TITLE
Add leaderboard using JSONBin

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,10 +62,45 @@
             font-size: 24px;
             display: none;
         }
+        #leaderboard {
+            position: absolute;
+            top: 0; left: 0; right: 0; bottom: 0;
+            background: rgba(0,0,0,0.8);
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            color: #0f0;
+            font-size: 20px;
+            display: none;
+        }
+        #leaderboard ol {
+            padding-left: 20px;
+            text-align: left;
+        }
+        .highlight {
+            color: yellow;
+        }
         #restart {
             margin-top: 10px;
             padding: 10px 20px;
             background: #333;
+            color: #0f0;
+            border: 1px solid #0f0;
+            font-size: 18px;
+        }
+        #submitScore, #showLeaderboard, #closeLeaderboard {
+            margin-top: 10px;
+            padding: 10px 20px;
+            background: #333;
+            color: #0f0;
+            border: 1px solid #0f0;
+            font-size: 18px;
+        }
+        #playerName {
+            margin-top: 10px;
+            padding: 5px;
+            background: #000;
             color: #0f0;
             border: 1px solid #0f0;
             font-size: 18px;
@@ -75,6 +110,7 @@
 <body>
     <h1>Snake Game</h1>
     <div id="score">Score: <span id="scoreValue">0</span></div>
+    <button id="showLeaderboard">Leaderboard</button>
     <canvas id="gameCanvas" width="600" height="600"></canvas>
     <div id="controls">
         <button id="up">↑</button>
@@ -84,7 +120,14 @@
     </div>
     <div id="gameOver">
         <div id="finalScore"></div>
+        <input id="playerName" type="text" placeholder="Your name" maxlength="20">
+        <button id="submitScore">Submit Score</button>
         <button id="restart">Restart</button>
+    </div>
+    <div id="leaderboard">
+        <h2>Leaderboard</h2>
+        <ol id="leaderboardList"></ol>
+        <button id="closeLeaderboard">Close</button>
     </div>
     <script>
     (() => {
@@ -100,6 +143,52 @@
         let speed = 200;
         let gameInterval;
         const highScoreKey = 'snakeHighScore';
+        // Replace the placeholders below with your own JSONBin details.
+        const JSONBIN_BIN_ID = '';
+        const JSONBIN_API_KEY = '';
+
+        async function fetchLeaderboard() {
+            if (!JSONBIN_BIN_ID) return [];
+            try {
+                const res = await fetch(`https://api.jsonbin.io/v3/b/${JSONBIN_BIN_ID}/latest`, {
+                    headers: { 'X-Master-Key': JSONBIN_API_KEY }
+                });
+                const data = await res.json();
+                return Array.isArray(data.record) ? data.record : [];
+            } catch (err) {
+                console.error('Failed to fetch leaderboard', err);
+                return [];
+            }
+        }
+
+        async function saveLeaderboard(entries) {
+            if (!JSONBIN_BIN_ID) return;
+            try {
+                await fetch(`https://api.jsonbin.io/v3/b/${JSONBIN_BIN_ID}`, {
+                    method: 'PUT',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-Master-Key': JSONBIN_API_KEY
+                    },
+                    body: JSON.stringify(entries)
+                });
+            } catch (err) {
+                console.error('Failed to save leaderboard', err);
+            }
+        }
+
+        function renderLeaderboard(entries, highlightName) {
+            const list = document.getElementById('leaderboardList');
+            list.innerHTML = '';
+            entries.forEach((e, i) => {
+                const li = document.createElement('li');
+                li.textContent = `#${i + 1} ${e.name} - ${e.score}`;
+                if (highlightName && e.name === highlightName && e.score === score) {
+                    li.classList.add('highlight');
+                }
+                list.appendChild(li);
+            });
+        }
 
         function randomFood() {
             let f;
@@ -161,14 +250,17 @@
             speed = 200;
             document.getElementById('scoreValue').textContent = score;
             document.getElementById('gameOver').style.display = 'none';
+            document.getElementById('leaderboard').style.display = 'none';
             restartInterval();
         }
 
         function endGame() {
             clearInterval(gameInterval);
             const high = Math.max(score, parseInt(localStorage.getItem(highScoreKey) || '0', 10));
-            localStorage.setItem(highScoreKey, high);
-            document.getElementById('finalScore').textContent = `Game Over! Score: ${score} (High: ${high})`;
+            const isNewHigh = score > high;
+            localStorage.setItem(highScoreKey, Math.max(high, score));
+            const msg = isNewHigh ? 'NEW HIGH SCORE! ' : '';
+            document.getElementById('finalScore').textContent = `${msg}Game Over! Score: ${score} (High: ${Math.max(high, score)})`;
             document.getElementById('gameOver').style.display = 'flex';
         }
 
@@ -241,6 +333,36 @@
         });
 
         document.getElementById('restart').addEventListener('click', resetGame);
+
+        document.getElementById('showLeaderboard').addEventListener('click', async () => {
+            const entries = await fetchLeaderboard();
+            entries.sort((a,b) => b.score - a.score);
+            entries.splice(10);
+            renderLeaderboard(entries);
+            document.getElementById('leaderboard').style.display = 'flex';
+        });
+
+        document.getElementById('closeLeaderboard').addEventListener('click', () => {
+            document.getElementById('leaderboard').style.display = 'none';
+        });
+
+        let lastSubmit = 0;
+        document.getElementById('submitScore').addEventListener('click', async () => {
+            const nameInput = document.getElementById('playerName');
+            const name = nameInput.value.trim();
+            if (!name) return alert('Please enter your name');
+            if (Date.now() - lastSubmit < 1000) return; // simple throttle
+            lastSubmit = Date.now();
+            const entries = await fetchLeaderboard();
+            entries.push({ name, score, ts: Date.now() });
+            entries.sort((a,b) => b.score - a.score);
+            if (entries.length > 10) entries.length = 10;
+            await saveLeaderboard(entries);
+            nameInput.value = '';
+            renderLeaderboard(entries, name);
+            document.getElementById('gameOver').style.display = 'none';
+            document.getElementById('leaderboard').style.display = 'flex';
+        });
 
         draw();
     })();


### PR DESCRIPTION
## Summary
- add leaderboard panel with name input and submission button
- store leaderboard entries in JSONBin via simple async functions
- allow users to fetch and view top scores
- highlight new high score and latest submission
- style new elements to match existing game

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68854092263c8323b14148b8823f5c1b